### PR TITLE
Configure API host by env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
-VITE_API_BASE_URL=/api
+# Set the application environment: development | staging | production
+VITE_ENV=development

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,0 +1,11 @@
+export type AppEnv = 'development' | 'staging' | 'production';
+
+const env = (import.meta.env.VITE_ENV as AppEnv | undefined) ?? (import.meta.env.MODE as AppEnv) ?? 'development';
+
+const API_BASE_URLS: Record<AppEnv, string> = {
+  development: 'http://localhost:5001',
+  staging: 'https://staging.example.com',
+  production: 'https://example.com',
+};
+
+export const API_BASE_URL = API_BASE_URLS[env] + '/api';

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,6 +1,5 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
-
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
+import { API_BASE_URL } from "@/config";
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- add `config.ts` with environment-specific API base URLs
- load API base URL from config in query client
- document new `VITE_ENV` variable in `.env.example`

## Testing
- `npm run check` *(fails: TS2322 errors)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685188a0b22c8328bc624283e065ffa2