### PR TITLE
Implement configurable CORS

### DIFF
--- a/python_server/config.py
+++ b/python_server/config.py
@@ -1,7 +1,13 @@
 from pydantic_settings import BaseSettings
+from typing import List
 
 class Settings(BaseSettings):
     database_url: str = "postgresql+asyncpg://ammaar:knaps@127.0.0.1/ammaar"
     node_env: str = "development"
+    cors_allow_origins: str = "http://localhost:5173"
+
+    @property
+    def cors_origins(self) -> List[str]:
+        return [origin.strip() for origin in self.cors_allow_origins.split(",") if origin.strip()]
 
 settings = Settings()

--- a/python_server/main.py
+++ b/python_server/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from .database import init_db
 from .config import settings
@@ -16,6 +17,15 @@ app = FastAPI()
 
 app.add_middleware(LoggingMiddleware)
 app.add_exception_handler(Exception, http_error_handler)
+
+# CORS configuration
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.cors_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.include_router(products_router)
 app.include_router(sell_ins_router)


### PR DESCRIPTION
## Summary
- enable CORS in the FastAPI server
- add CORS configuration via environment variables

## Testing
- `npm run check` *(fails: TS errors)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68518bfec5188328b1607fc3aeb2e030