### PR TITLE
Split client/server services

### DIFF
--- a/.replit
+++ b/.replit
@@ -8,10 +8,10 @@ channel = "stable-24_05"
 [deployment]
 deploymentTarget = "autoscale"
 build = ["bash", "-lc", "pip install -r requirements.txt && npm run build"]
-run = ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:5001", "python_server.main:app"]
+run = ["node", "server/index.js"]
 
 [[ports]]
-localPort = 5001
+localPort = 3000
 externalPort = 80
 
 [workflows]

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "NODE_ENV=development bash -c 'vite build --watch & uvicorn python_server.main:app --reload --host 0.0.0.0 --port 5001'",
+    "dev": "NODE_ENV=development bash -c 'vite build --watch & tsx watch server/index.js'",
     "build": "vite build",
-    "start": "gunicorn -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:5001 python_server.main:app",
+    "start": "node server/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"
   },

--- a/python_server/main.py
+++ b/python_server/main.py
@@ -11,7 +11,6 @@ from .routes.products.router import router as products_router
 from .routes.sell_ins.router import router as sell_ins_router
 from .routes.sell_throughs.router import router as sell_throughs_router
 from .routes.analytics.router import router as analytics_router
-from .static import mount_static
 
 app = FastAPI()
 
@@ -35,7 +34,5 @@ app.include_router(analytics_router)
 @app.on_event("startup")
 async def startup():
     await init_db()
-    log("serving on port 5001")
+    log("serving API on port 5001")
 
-# Serve prebuilt frontend
-mount_static(app)

--- a/replit.md
+++ b/replit.md
@@ -6,6 +6,11 @@ This is a full-stack electronics franchise management system built with React, F
 
 ## System Architecture
 
+This project is split into two micro services:
+
+1. **Client Service** – a React application served by a lightweight Express server. The client code lives in `client/` and the Express server code lives in `server/`.
+2. **API Service** – a FastAPI application located in `python_server/`.
+
 ### Frontend Architecture
 - **Framework**: React 18 with TypeScript
 - **Build Tool**: Vite for fast development and optimized builds
@@ -91,19 +96,19 @@ This is a full-stack electronics franchise management system built with React, F
 ## Deployment Strategy
 
 ### Development Environment
-- **Command**: `npm run dev`
-- **Server**: FastAPI served by Uvicorn with hot reload
-- **Client**: Vite builds static assets in watch mode (no dev server)
+- **Client Command**: `npm run dev` – builds the React app in watch mode and runs the Express server.
+- **API Command**: `uvicorn python_server.main:app --reload --host 0.0.0.0 --port 5001`
 - **Database**: PostgreSQL connection via environment variable
 
 ### Production Build
-- **Client Build**: `vite build` - Creates optimized static assets
-- **Server Build**: Python modules installed from `requirements.txt`
-- **Start Command**: `npm run start` - Runs Gunicorn with Uvicorn workers
+ - **Client Build**: `vite build` – produces static assets served by Express
+ - **API Build**: install Python modules from `requirements.txt`
+ - **Client Start**: `npm start`
+ - **API Start**: `gunicorn -k uvicorn.workers.UvicornWorker python_server.main:app`
 
 ### Platform Configuration
-- **Deployment Target**: Replit autoscale infrastructure
- - **Port Configuration**: Server runs on port 5001, exposed as port 80
+ - **Deployment Target**: Replit autoscale infrastructure
+ - **Port Configuration**: Client service runs on port 3000 and the API service on port 5001
 - **Environment**: Node.js 20, Python 3.11, and PostgreSQL 16 modules
 - **Build Process**: Automated via Replit deployment configuration
 

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,18 @@
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const app = express();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const publicDir = path.join(__dirname, '..', 'dist', 'public');
+
+app.use(express.static(publicDir));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(publicDir, 'index.html'));
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Client service listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add express server for React build
- stop FastAPI from serving the React build
- adjust run scripts for separate services
- update Replit config
- document new microservice architecture

## Testing
- `npm run check` *(fails: TS errors)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6851c71fbe84832888ecaf7a0718b1af