### PR TITLE
Add structured logging with dictConfig

### DIFF
--- a/python_server/logging_config.py
+++ b/python_server/logging_config.py
@@ -1,0 +1,55 @@
+import json
+import logging
+import logging.config
+import os
+from logging.handlers import TimedRotatingFileHandler
+
+
+class JsonFormatter(logging.Formatter):
+    """Format log records as compact JSON."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        data = {
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        for attr in ("request_id", "method", "path", "status", "duration_ms", "body"):
+            value = getattr(record, attr, None)
+            if value is not None:
+                data[attr] = value
+        return json.dumps(data)
+
+
+LOG_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "console": {"format": "%(levelname)s %(name)s - %(message)s"},
+        "json": {"()": "python_server.logging_config.JsonFormatter"},
+    },
+    "handlers": {
+        "console": {"class": "logging.StreamHandler", "formatter": "console"},
+        "file": {
+            "class": "logging.handlers.TimedRotatingFileHandler",
+            "filename": os.path.join("logs", "api.log"),
+            "when": "midnight",
+            "backupCount": 7,
+            "formatter": "json",
+        },
+    },
+    "loggers": {
+        "knaps": {"handlers": ["console", "file"], "level": "INFO"},
+        "uvicorn.error": {"handlers": ["console", "file"], "level": "INFO", "propagate": False},
+        "uvicorn.access": {"handlers": ["console", "file"], "level": "INFO", "propagate": False},
+    },
+}
+
+
+def setup_logging() -> logging.Logger:
+    os.makedirs("logs", exist_ok=True)
+    logging.config.dictConfig(LOG_CONFIG)
+    return logging.getLogger("knaps")
+
+
+LOG = setup_logging()

--- a/python_server/main.py
+++ b/python_server/main.py
@@ -3,10 +3,8 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .database import init_db
 from .config import settings
-from .middleware import log
-
-
-from .middleware import LoggingMiddleware, http_error_handler
+from .logging_config import LOG
+from .middleware import StructuredLoggingMiddleware, http_error_handler
 from .routes.products.router import router as products_router
 from .routes.sell_ins.router import router as sell_ins_router
 from .routes.sell_throughs.router import router as sell_throughs_router
@@ -14,7 +12,7 @@ from .routes.analytics.router import router as analytics_router
 
 app = FastAPI()
 
-app.add_middleware(LoggingMiddleware)
+app.add_middleware(StructuredLoggingMiddleware)
 app.add_exception_handler(Exception, http_error_handler)
 
 # CORS configuration
@@ -31,8 +29,8 @@ app.include_router(sell_ins_router)
 app.include_router(sell_throughs_router)
 app.include_router(analytics_router)
 
+
 @app.on_event("startup")
 async def startup():
     await init_db()
-    log("serving API on port 5001")
-
+    LOG.info("serving API on port 5001")

--- a/python_server/middleware.py
+++ b/python_server/middleware.py
@@ -1,43 +1,69 @@
-from fastapi import Request, Response
+import json
+import logging
+import time
+import uuid
+from fastapi import Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
-import json
-import time
-from datetime import datetime
+
+logger = logging.getLogger("knaps")
 
 
-def log(message: str, source: str = "fastapi") -> None:
-    formatted_time = datetime.now().strftime("%I:%M:%S %p")
-    print(f"{formatted_time} [{source}] {message}")
-
-class LoggingMiddleware(BaseHTTPMiddleware):
+class StructuredLoggingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
+        request_id = str(uuid.uuid4())
+        request.state.request_id = request_id
+
+        try:
+            body_bytes = await request.body()
+            request._body = body_bytes
+            body_text = body_bytes.decode("utf-8")
+        except Exception:
+            body_text = ""
+        if len(body_text) > 100:
+            body_text = body_text[:97] + "..."
+
+        logger.info(
+            "request",
+            extra={
+                "request_id": request_id,
+                "method": request.method,
+                "path": request.url.path,
+                "body": body_text,
+            },
+        )
+
         start = time.time()
         response = await call_next(request)
         duration = int((time.time() - start) * 1000)
 
-        if request.url.path.startswith('/api'):
-            body = getattr(response, 'body', None)
-            summary = ''
-            if body:
-                try:
-                    summary = json.dumps(json.loads(body))
-                except Exception:
-                    pass
-            log_line = f"{request.method} {request.url.path} {response.status_code} in {duration}ms"
-            if summary:
-                log_line += f" :: {summary}"
-            if len(log_line) > 80:
-                log_line = log_line[:79] + '…'
-            log(log_line)
+        resp_body = getattr(response, "body", b"")
+        try:
+            resp_text = resp_body.decode("utf-8") if resp_body else ""
+        except Exception:
+            resp_text = ""
+        if len(resp_text) > 100:
+            resp_text = resp_text[:97] + "..."
+
+        logger.info(
+            "response",
+            extra={
+                "request_id": request_id,
+                "status": response.status_code,
+                "duration_ms": duration,
+                "body": resp_text,
+            },
+        )
         return response
+
 
 async def http_error_handler(request: Request, exc: Exception):
     from fastapi import HTTPException
+
     if isinstance(exc, HTTPException):
         status = exc.status_code
         message = exc.detail
     else:
         status = 500
-        message = 'Internal Server Error'
-    return JSONResponse(status_code=status, content={'message': message})
+        message = "Internal Server Error"
+    return JSONResponse(status_code=status, content={"message": message})


### PR DESCRIPTION
## Summary
- configure logging via `logging.config.dictConfig`
- capture requests and responses in new middleware
- log API startup with the structured logger

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6851d55effe48328b164b2944ce9aea3