### PR TITLE
Fix logging config import loop

### DIFF
--- a/python_server/logging_config.py
+++ b/python_server/logging_config.py
@@ -26,7 +26,7 @@ LOG_CONFIG = {
     "disable_existing_loggers": False,
     "formatters": {
         "console": {"format": "%(levelname)s %(name)s - %(message)s"},
-        "json": {"()": "python_server.logging_config.JsonFormatter"},
+        "json": {"()": JsonFormatter},
     },
     "handlers": {
         "console": {"class": "logging.StreamHandler", "formatter": "console"},


### PR DESCRIPTION
## Summary
- remove string-based reference to JsonFormatter to avoid circular import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6851d6ff69a88328998e575472b64761