### PR TITLE
Improve logging middleware resilience

### DIFF
--- a/python_server/middleware.py
+++ b/python_server/middleware.py
@@ -1,27 +1,26 @@
-import json
 import logging
 import time
 import uuid
 from fastapi import Request
 from fastapi.responses import JSONResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 
 logger = logging.getLogger("knaps")
 
 
-class StructuredLoggingMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next):
-        request_id = str(uuid.uuid4())
-        request.state.request_id = request_id
+class StructuredLoggingMiddleware:
+    """ASGI middleware for logging request and response details."""
 
-        try:
-            body_bytes = await request.body()
-            request._body = body_bytes
-            body_text = body_bytes.decode("utf-8")
-        except Exception:
-            body_text = ""
-        if len(body_text) > 100:
-            body_text = body_text[:97] + "..."
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope, receive)
+        request_id = str(uuid.uuid4())
+        scope.setdefault("state", {})["request_id"] = request_id
 
         logger.info(
             "request",
@@ -29,32 +28,29 @@ class StructuredLoggingMiddleware(BaseHTTPMiddleware):
                 "request_id": request_id,
                 "method": request.method,
                 "path": request.url.path,
-                "body": body_text,
             },
         )
 
         start = time.time()
-        response = await call_next(request)
-        duration = int((time.time() - start) * 1000)
+        status_code = 500
 
-        resp_body = getattr(response, "body", b"")
-        try:
-            resp_text = resp_body.decode("utf-8") if resp_body else ""
-        except Exception:
-            resp_text = ""
-        if len(resp_text) > 100:
-            resp_text = resp_text[:97] + "..."
+        async def send_wrapper(message):
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+        duration = int((time.time() - start) * 1000)
 
         logger.info(
             "response",
             extra={
                 "request_id": request_id,
-                "status": response.status_code,
+                "status": status_code,
                 "duration_ms": duration,
-                "body": resp_text,
             },
         )
-        return response
 
 
 async def http_error_handler(request: Request, exc: Exception):


### PR DESCRIPTION
## Summary
- simplify logging middleware implementation
- switch to ASGI style to avoid BaseHTTPMiddleware issues

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6851d8fb0ce88328a573218cd9604e32