### PR TITLE
Add TypeScript server entry

### DIFF
--- a/.replit
+++ b/.replit
@@ -8,7 +8,7 @@ channel = "stable-24_05"
 [deployment]
 deploymentTarget = "autoscale"
 build = ["bash", "-lc", "pip install -r requirements.txt && npm run build"]
-run = ["node", "server/index.js"]
+run = ["node", "dist/index.js"]
 
 [[ports]]
 localPort = 3000

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,23 +1,15 @@
 import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { ReactKeycloakProvider } from "@react-keycloak/web";
-import { keycloak } from "./keycloak";
-ReactDOM.render(
-  <ReactKeycloakProvider authClient={keycloak}>
-    <App />
-  </ReactKeycloakProvider>,
-  document.getElementById("root")
-);
 
-
-const app = express();
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicDir = path.join(__dirname, '..', 'dist', 'public');
 
+const app = express();
+
 app.use(express.static(publicDir));
 
-app.get('*', (req, res) => {
+app.get('*', (_req, res) => {
   res.sendFile(path.join(publicDir, 'index.html'));
 });
 


### PR DESCRIPTION
## Summary
- add a new TypeScript server entry point
- remove the old JS entry that contained React code
- update `.replit` deploy command to run the compiled server

## Testing
- `npm run check` *(fails: type errors in components)*

------
https://chatgpt.com/codex/tasks/task_e_685c8d578ddc8328acb16b55d33e46f7