### PR TITLE
Add CTC hierarchy page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import ProductManagement from "@/pages/product-management";
 import DistributorsPage from "@/pages/distributors";
+import CTCHierarchyPage from "@/pages/ctc-hierarchy";
 import NotFound from "@/pages/not-found";
 import { keycloak, keycloakConfig } from "./keycloak";
 
@@ -16,6 +17,7 @@ function Router() {
       <Route path="/" component={ProductManagement} />
       <Route path="/products" component={ProductManagement} />
       <Route path="/distributors" component={DistributorsPage} />
+      <Route path="/ctc" component={CTCHierarchyPage} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -1,10 +1,11 @@
-import { Box, ChartLine, Warehouse, Users, Settings } from "lucide-react";
+import { Box, Boxes, ChartLine, Warehouse, Users, Settings } from "lucide-react";
 import { Link, useLocation } from "wouter";
 import { cn } from "@/lib/utils";
 
 const navigation = [
   { name: 'Product Management', href: '/products', icon: Box },
   { name: 'Distributors & Brands', href: '/distributors', icon: Warehouse },
+  { name: 'CTC Hierarchy', href: '/ctc', icon: Boxes },
   { name: 'Sales Analytics', href: '#', icon: ChartLine },
   { name: 'Inventory', href: '#', icon: Warehouse },
   { name: 'Customers', href: '#', icon: Users },

--- a/client/src/pages/ctc-hierarchy.tsx
+++ b/client/src/pages/ctc-hierarchy.tsx
@@ -1,7 +1,7 @@
 import Sidebar from "@/components/sidebar";
 import UserMenu from "@/components/user-menu";
 import { useQuery } from "@tanstack/react-query";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
   Accordion,
@@ -9,6 +9,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { Badge } from "@/components/ui/badge";
 import { Store, Bell } from "lucide-react";
 
 interface CTCCategoryHierarchy {
@@ -86,7 +87,9 @@ export default function CTCHierarchyPage() {
                                 <ul className="list-disc pl-6 space-y-1 p-2">
                                   {type.categories.map((cat) => (
                                     <li key={cat.id} className="text-sm text-gray-700">
-                                      {cat.name}
+                                      <Badge variant="secondary" className="bg-gray-100">
+                                        {cat.name}
+                                      </Badge>
                                     </li>
                                   ))}
                                 </ul>

--- a/client/src/pages/ctc-hierarchy.tsx
+++ b/client/src/pages/ctc-hierarchy.tsx
@@ -84,15 +84,16 @@ export default function CTCHierarchyPage() {
                                 {type.name}
                               </AccordionTrigger>
                               <AccordionContent>
-                                <ul className="list-disc pl-6 space-y-1 p-2">
+                                <div className="space-y-1 p-2">
                                   {type.categories.map((cat) => (
-                                    <li key={cat.id} className="text-sm text-gray-700">
-                                      <Badge variant="secondary" className="bg-gray-100">
-                                        {cat.name}
-                                      </Badge>
-                                    </li>
+                                    <div
+                                      key={cat.id}
+                                      className="text-sm text-gray-700 bg-gray-100 rounded px-2 py-1"
+                                    >
+                                      {cat.name}
+                                    </div>
                                   ))}
-                                </ul>
+                                </div>
                               </AccordionContent>
                             </AccordionItem>
                           ))}

--- a/client/src/pages/ctc-hierarchy.tsx
+++ b/client/src/pages/ctc-hierarchy.tsx
@@ -9,7 +9,6 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-import { Badge } from "@/components/ui/badge";
 import { Store, Bell } from "lucide-react";
 
 interface CTCCategoryHierarchy {
@@ -84,13 +83,13 @@ export default function CTCHierarchyPage() {
                                 {type.name}
                               </AccordionTrigger>
                               <AccordionContent>
-                                <div className="flex flex-wrap gap-2 p-2">
+                                <ul className="list-disc pl-6 space-y-1 p-2">
                                   {type.categories.map((cat) => (
-                                    <Badge key={cat.id} variant="secondary" className="whitespace-nowrap">
+                                    <li key={cat.id} className="text-sm text-gray-700">
                                       {cat.name}
-                                    </Badge>
+                                    </li>
                                   ))}
-                                </div>
+                                </ul>
                               </AccordionContent>
                             </AccordionItem>
                           ))}

--- a/client/src/pages/ctc-hierarchy.tsx
+++ b/client/src/pages/ctc-hierarchy.tsx
@@ -1,0 +1,91 @@
+import Sidebar from "@/components/sidebar";
+import UserMenu from "@/components/user-menu";
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Store, Bell } from "lucide-react";
+
+interface CTCCategoryHierarchy {
+  id: number;
+  uuid: string;
+  code: string;
+  name: string;
+  active: boolean;
+  product_id?: number | null;
+}
+
+interface CTCTypeHierarchy {
+  id: number;
+  uuid: string;
+  code: string;
+  name: string;
+  active: boolean;
+  categories: CTCCategoryHierarchy[];
+}
+
+interface CTCClassHierarchy {
+  id: number;
+  uuid: string;
+  code: string;
+  name: string;
+  active: boolean;
+  types: CTCTypeHierarchy[];
+}
+
+export default function CTCHierarchyPage() {
+  const { data: classes = [], isLoading } = useQuery<CTCClassHierarchy[]>({
+    queryKey: ["/ctc/hierarchy"],
+  });
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow-sm border-b border-gray-200 sticky top-0 z-50">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div className="flex items-center">
+              <Store className="text-primary text-2xl mr-3" />
+              <h1 className="text-xl font-semibold text-gray-900">CTC Hierarchy</h1>
+            </div>
+            <div className="flex items-center space-x-4">
+              <Button variant="ghost" size="icon">
+                <Bell className="h-5 w-5 text-gray-400" />
+              </Button>
+              <UserMenu />
+            </div>
+          </div>
+        </div>
+      </header>
+      <div className="flex h-screen pt-16">
+        <Sidebar />
+        <main className="flex-1 overflow-auto p-6 space-y-6">
+          {isLoading ? (
+            <div>Loading...</div>
+          ) : (
+            classes.map((cls) => (
+              <Card key={cls.id} className="">
+                <CardHeader>
+                  <CardTitle>{cls.name}</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {cls.types.map((type) => (
+                    <div key={type.id}>
+                      <div className="font-semibold text-gray-700">{type.name}</div>
+                      <ul className="ml-4 list-disc">
+                        {type.categories.map((cat) => (
+                          <li key={cat.id} className="text-gray-600">
+                            {cat.name}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            ))
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+

--- a/client/src/pages/ctc-hierarchy.tsx
+++ b/client/src/pages/ctc-hierarchy.tsx
@@ -1,6 +1,7 @@
 import Sidebar from "@/components/sidebar";
 import UserMenu from "@/components/user-menu";
 import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
@@ -44,6 +45,24 @@ export default function CTCHierarchyPage() {
     queryKey: ["/ctc/hierarchy"],
   });
 
+  const [openClasses, setOpenClasses] = useState<string[]>([]);
+  const [openTypes, setOpenTypes] = useState<Record<number, string[]>>({});
+
+  const expandAll = () => {
+    const classValues = classes.map((cls) => `class-${cls.id}`);
+    const typeState: Record<number, string[]> = {};
+    classes.forEach((cls) => {
+      typeState[cls.id] = cls.types.map((t) => `type-${t.id}`);
+    });
+    setOpenClasses(classValues);
+    setOpenTypes(typeState);
+  };
+
+  const collapseAll = () => {
+    setOpenClasses([]);
+    setOpenTypes({});
+  };
+
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="bg-white shadow-sm border-b border-gray-200 sticky top-0 z-50">
@@ -65,10 +84,23 @@ export default function CTCHierarchyPage() {
       <div className="flex h-screen pt-16">
         <Sidebar />
         <main className="flex-1 overflow-auto p-6 space-y-6">
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={expandAll}>
+              Expand All
+            </Button>
+            <Button variant="outline" onClick={collapseAll}>
+              Collapse All
+            </Button>
+          </div>
           {isLoading ? (
             <div>Loading...</div>
           ) : (
-            <Accordion type="multiple" className="space-y-4">
+            <Accordion
+              type="multiple"
+              className="space-y-4"
+              value={openClasses}
+              onValueChange={setOpenClasses}
+            >
               {classes.map((cls) => (
                 <AccordionItem value={`class-${cls.id}`} key={cls.id}>
                   <Card>
@@ -77,7 +109,14 @@ export default function CTCHierarchyPage() {
                     </AccordionTrigger>
                     <AccordionContent>
                       <CardContent className="space-y-2">
-                        <Accordion type="multiple" className="space-y-2">
+                        <Accordion
+                          type="multiple"
+                          className="space-y-2"
+                          value={openTypes[cls.id] ?? []}
+                          onValueChange={(v) =>
+                            setOpenTypes((prev) => ({ ...prev, [cls.id]: v }))
+                          }
+                        >
                           {cls.types.map((type) => (
                             <AccordionItem value={`type-${type.id}`} key={type.id}>
                               <AccordionTrigger className="px-4 py-2 bg-gray-50 rounded text-left font-medium">

--- a/client/src/pages/ctc-hierarchy.tsx
+++ b/client/src/pages/ctc-hierarchy.tsx
@@ -3,6 +3,13 @@ import UserMenu from "@/components/user-menu";
 import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Badge } from "@/components/ui/badge";
 import { Store, Bell } from "lucide-react";
 
 interface CTCCategoryHierarchy {
@@ -61,27 +68,39 @@ export default function CTCHierarchyPage() {
           {isLoading ? (
             <div>Loading...</div>
           ) : (
-            classes.map((cls) => (
-              <Card key={cls.id} className="">
-                <CardHeader>
-                  <CardTitle>{cls.name}</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  {cls.types.map((type) => (
-                    <div key={type.id}>
-                      <div className="font-semibold text-gray-700">{type.name}</div>
-                      <ul className="ml-4 list-disc">
-                        {type.categories.map((cat) => (
-                          <li key={cat.id} className="text-gray-600">
-                            {cat.name}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  ))}
-                </CardContent>
-              </Card>
-            ))
+            <Accordion type="multiple" className="space-y-4">
+              {classes.map((cls) => (
+                <AccordionItem value={`class-${cls.id}`} key={cls.id}>
+                  <Card>
+                    <AccordionTrigger className="px-4 py-2 text-lg font-semibold text-left">
+                      {cls.name}
+                    </AccordionTrigger>
+                    <AccordionContent>
+                      <CardContent className="space-y-2">
+                        <Accordion type="multiple" className="space-y-2">
+                          {cls.types.map((type) => (
+                            <AccordionItem value={`type-${type.id}`} key={type.id}>
+                              <AccordionTrigger className="px-4 py-2 bg-gray-50 rounded text-left font-medium">
+                                {type.name}
+                              </AccordionTrigger>
+                              <AccordionContent>
+                                <div className="flex flex-wrap gap-2 p-2">
+                                  {type.categories.map((cat) => (
+                                    <Badge key={cat.id} variant="secondary" className="whitespace-nowrap">
+                                      {cat.name}
+                                    </Badge>
+                                  ))}
+                                </div>
+                              </AccordionContent>
+                            </AccordionItem>
+                          ))}
+                        </Accordion>
+                      </CardContent>
+                    </AccordionContent>
+                  </Card>
+                </AccordionItem>
+              ))}
+            </Accordion>
           )}
         </main>
       </div>


### PR DESCRIPTION
## Summary
- implement CTC hierarchy page for viewing class/type/category tree
- register route and navigation link

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686c3241e3848328a15df8588e6939ed