### PR TITLE
Add Core Range Products page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import ProductManagement from "@/pages/product-management";
 import DistributorsPage from "@/pages/distributors";
 import CTCHierarchyPage from "@/pages/ctc-hierarchy";
+import CoreRangeProducts from "@/pages/core-range-products";
 import NotFound from "@/pages/not-found";
 import { keycloak, keycloakConfig } from "./keycloak";
 
@@ -18,6 +19,7 @@ function Router() {
       <Route path="/products" component={ProductManagement} />
       <Route path="/distributors" component={DistributorsPage} />
       <Route path="/ctc-hierarchy" component={CTCHierarchyPage} />
+      <Route path="/core-range-products" component={CoreRangeProducts} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/core-range/Filters.tsx
+++ b/client/src/components/core-range/Filters.tsx
@@ -1,0 +1,162 @@
+import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { apiRequest } from "@/lib/queryClient";
+import type { DistributorRead, BrandRead } from "@shared/schema";
+
+interface CTCLevel {
+  id: number;
+  name: string;
+  types?: CTCLevel[];
+  categories?: CTCLevel[];
+}
+
+export interface FilterValues {
+  distributor_id?: number;
+  brand_id?: number;
+  class_id?: number;
+  type_id?: number;
+  category_id?: number;
+}
+
+interface FiltersProps {
+  onSubmit: (values: FilterValues) => void;
+}
+
+export default function Filters({ onSubmit }: FiltersProps) {
+  const [distributor, setDistributor] = useState("");
+  const [brand, setBrand] = useState("");
+  const [classId, setClassId] = useState("");
+  const [typeId, setTypeId] = useState("");
+  const [categoryId, setCategoryId] = useState("");
+
+  const { data: distributors = [] } = useQuery<DistributorRead[]>({
+    queryKey: ["/distributors"],
+  });
+
+  const { data: brands = [] } = useQuery<BrandRead[]>({
+    queryKey: ["/brands/distributor", distributor],
+    queryFn: async () => {
+      if (!distributor) return [];
+      const res = await apiRequest("GET", `/brands/distributor/${distributor}`);
+      return res.json();
+    },
+    enabled: !!distributor,
+  });
+
+  const { data: hierarchy = [] } = useQuery<CTCLevel[]>({
+    queryKey: ["/ctc/hierarchy"],
+    queryFn: async () => {
+      const res = await apiRequest("GET", "/ctc/hierarchy");
+      return res.json();
+    },
+  });
+
+  useEffect(() => {
+    setBrand("");
+  }, [distributor]);
+
+  useEffect(() => {
+    setTypeId("");
+    setCategoryId("");
+  }, [classId]);
+
+  useEffect(() => {
+    setCategoryId("");
+  }, [typeId]);
+
+  const selectedClass = hierarchy.find((c) => String(c.id) === classId);
+  const typeOptions = selectedClass?.types || [];
+  const selectedType = typeOptions.find((t) => String(t.id) === typeId);
+  const categoryOptions = selectedType?.categories || [];
+
+  const handleSubmit = () => {
+    const values: FilterValues = {};
+    if (distributor) values.distributor_id = Number(distributor);
+    if (brand) values.brand_id = Number(brand);
+    if (classId) values.class_id = Number(classId);
+    if (typeId) values.type_id = Number(typeId);
+    if (categoryId) values.category_id = Number(categoryId);
+    onSubmit(values);
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-4">
+      <Select value={brand} onValueChange={setBrand} disabled={!brands.length}>
+        <SelectTrigger>
+          <SelectValue placeholder="Brand" />
+        </SelectTrigger>
+        <SelectContent>
+          {brands.map((b) => (
+            <SelectItem key={b.id} value={String(b.id)}>
+              {b.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select value={distributor} onValueChange={setDistributor}>
+        <SelectTrigger>
+          <SelectValue placeholder="Distributor" />
+        </SelectTrigger>
+        <SelectContent>
+          {distributors.map((d) => (
+            <SelectItem key={d.id} value={String(d.id)}>
+              {d.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select value={classId} onValueChange={setClassId}>
+        <SelectTrigger>
+          <SelectValue placeholder="Class" />
+        </SelectTrigger>
+        <SelectContent>
+          {hierarchy.map((c) => (
+            <SelectItem key={c.id} value={String(c.id)}>
+              {c.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select value={typeId} onValueChange={setTypeId} disabled={!typeOptions.length}>
+        <SelectTrigger>
+          <SelectValue placeholder="Type" />
+        </SelectTrigger>
+        <SelectContent>
+          {typeOptions.map((t) => (
+            <SelectItem key={t.id} value={String(t.id)}>
+              {t.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select value={categoryId} onValueChange={setCategoryId} disabled={!categoryOptions.length}>
+        <SelectTrigger>
+          <SelectValue placeholder="Category" />
+        </SelectTrigger>
+        <SelectContent>
+          {categoryOptions.map((c) => (
+            <SelectItem key={c.id} value={String(c.id)}>
+              {c.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <div className="md:col-span-5 flex justify-end">
+        <Button onClick={handleSubmit}>Submit</Button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/core-range/Filters.tsx
+++ b/client/src/components/core-range/Filters.tsx
@@ -8,6 +8,7 @@ import {
   SelectItem,
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { apiRequest } from "@/lib/queryClient";
 import type { DistributorRead, BrandRead } from "@shared/schema";
 
@@ -24,6 +25,7 @@ export interface FilterValues {
   class_id?: number;
   type_id?: number;
   category_id?: number;
+  core_groups?: string[];
 }
 
 interface FiltersProps {
@@ -36,6 +38,18 @@ export default function Filters({ onSubmit }: FiltersProps) {
   const [classId, setClassId] = useState("");
   const [typeId, setTypeId] = useState("");
   const [categoryId, setCategoryId] = useState("");
+  const [coreGroups, setCoreGroups] = useState<string[]>([]);
+
+  const allGroups = ["A", "B", "C", "D", "E"];
+
+  const toggleGroup = (g: string) => {
+    setCoreGroups((prev) =>
+      prev.includes(g) ? prev.filter((x) => x !== g) : [...prev, g],
+    );
+  };
+
+  const selectAll = () => setCoreGroups(allGroups);
+  const deselectAll = () => setCoreGroups([]);
 
   const { data: distributors = [] } = useQuery<DistributorRead[]>({
     queryKey: ["/distributors"],
@@ -84,6 +98,7 @@ export default function Filters({ onSubmit }: FiltersProps) {
     if (classId) values.class_id = Number(classId);
     if (typeId) values.type_id = Number(typeId);
     if (categoryId) values.category_id = Number(categoryId);
+    if (coreGroups.length) values.core_groups = coreGroups;
     onSubmit(values);
   };
 
@@ -153,6 +168,27 @@ export default function Filters({ onSubmit }: FiltersProps) {
           ))}
         </SelectContent>
       </Select>
+
+      <div className="md:col-span-5 flex items-center flex-wrap gap-4">
+        {allGroups.map((g) => (
+          <div key={g} className="flex items-center space-x-2">
+            <Checkbox
+              id={`core-${g}`}
+              checked={coreGroups.includes(g)}
+              onCheckedChange={() => toggleGroup(g)}
+            />
+            <label htmlFor={`core-${g}`} className="text-sm">
+              {g}
+            </label>
+          </div>
+        ))}
+        <Button variant="outline" size="sm" type="button" onClick={selectAll}>
+          Select All
+        </Button>
+        <Button variant="outline" size="sm" type="button" onClick={deselectAll}>
+          Deselect All
+        </Button>
+      </div>
 
       <div className="md:col-span-5 flex justify-end">
         <Button onClick={handleSubmit}>Submit</Button>

--- a/client/src/components/core-range/Pagination.tsx
+++ b/client/src/components/core-range/Pagination.tsx
@@ -1,0 +1,31 @@
+import { Pagination, PaginationContent, PaginationItem, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+
+interface Props {
+  page: number;
+  pageCount: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function TablePagination({ page, pageCount, onPageChange }: Props) {
+  return (
+    <Pagination className="my-4">
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious
+            className="cursor-pointer"
+            onClick={() => onPageChange(Math.max(0, page - 1))}
+          />
+        </PaginationItem>
+        <PaginationItem className="flex items-center px-3 text-sm">
+          Page {page + 1} of {pageCount}
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext
+            className="cursor-pointer"
+            onClick={() => onPageChange(Math.min(pageCount - 1, page + 1))}
+          />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+}

--- a/client/src/components/core-range/ProductsTable.tsx
+++ b/client/src/components/core-range/ProductsTable.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils";
 interface Product {
   id: number;
   brand_name?: string;
+  ctc_class_name?: string;
   product_name?: string;
   core_group?: string;
   rank?: number;
@@ -59,6 +60,7 @@ export default function ProductsTable({ products, loading, error }: ProductsTabl
           <TableRow>
             <TableHead>Product ID</TableHead>
             <TableHead>Brand</TableHead>
+            <TableHead>Class</TableHead>
             <TableHead>Product Name</TableHead>
             <TableHead>Core</TableHead>
             <TableHead>Rank</TableHead>
@@ -78,6 +80,7 @@ export default function ProductsTable({ products, loading, error }: ProductsTabl
             <TableRow key={p.id}>
               <TableCell>{p.id}</TableCell>
               <TableCell>{p.brand_name || ""}</TableCell>
+              <TableCell>{p.ctc_class_name || ""}</TableCell>
               <TableCell>{p.product_name || ""}</TableCell>
               <TableCell>
                 {p.core_group ? (

--- a/client/src/components/core-range/ProductsTable.tsx
+++ b/client/src/components/core-range/ProductsTable.tsx
@@ -1,0 +1,87 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface Product {
+  id: number;
+  brand_name?: string;
+  core_group?: string;
+  rank?: number;
+  net_after_sta?: string;
+  go?: string;
+  cat_sale_price?: string;
+  gp_dollar?: string;
+  gp_percent?: string;
+  cat_sale?: string;
+  cat_sale_end_date?: string;
+  soh?: string;
+  soo?: string;
+}
+
+interface ProductsTableProps {
+  products: Product[];
+  loading: boolean;
+  error: boolean;
+}
+
+export default function ProductsTable({ products, loading, error }: ProductsTableProps) {
+  if (loading) {
+    return <div className="p-6">Loading...</div>;
+  }
+
+  if (error) {
+    return <div className="p-6 text-red-500">Error loading products</div>;
+  }
+
+  if (products.length === 0) {
+    return <div className="p-6 text-gray-500">No products found</div>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Product ID</TableHead>
+            <TableHead>Brand</TableHead>
+            <TableHead>Core</TableHead>
+            <TableHead>Rank</TableHead>
+            <TableHead>Net (incl.) After STA</TableHead>
+            <TableHead>Go</TableHead>
+            <TableHead>Cat/Sale Price</TableHead>
+            <TableHead>GP $</TableHead>
+            <TableHead>GP %</TableHead>
+            <TableHead>Cat/Sale</TableHead>
+            <TableHead>Cat/Sale End Date</TableHead>
+            <TableHead>SOH</TableHead>
+            <TableHead>SOO</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {products.map((p) => (
+            <TableRow key={p.id}>
+              <TableCell>{p.id}</TableCell>
+              <TableCell>{p.brand_name || ""}</TableCell>
+              <TableCell>{p.core_group || ""}</TableCell>
+              <TableCell>{p.rank ?? ""}</TableCell>
+              <TableCell>{p.net_after_sta || ""}</TableCell>
+              <TableCell>{p.go || ""}</TableCell>
+              <TableCell>{p.cat_sale_price || ""}</TableCell>
+              <TableCell>{p.gp_dollar || ""}</TableCell>
+              <TableCell>{p.gp_percent || ""}</TableCell>
+              <TableCell>{p.cat_sale || ""}</TableCell>
+              <TableCell>{p.cat_sale_end_date || ""}</TableCell>
+              <TableCell>{p.soh || ""}</TableCell>
+              <TableCell>{p.soo || ""}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/client/src/components/core-range/ProductsTable.tsx
+++ b/client/src/components/core-range/ProductsTable.tsx
@@ -6,10 +6,12 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
 
 interface Product {
   id: number;
   brand_name?: string;
+  product_name?: string;
   core_group?: string;
   rank?: number;
   net_after_sta?: string;
@@ -22,6 +24,14 @@ interface Product {
   soh?: string;
   soo?: string;
 }
+
+const groupColors: Record<string, string> = {
+  A: "bg-green-100 text-green-800",
+  B: "bg-blue-100 text-blue-800",
+  C: "bg-yellow-100 text-yellow-800",
+  D: "bg-red-100 text-red-800",
+  E: "bg-gray-100 text-gray-800",
+};
 
 interface ProductsTableProps {
   products: Product[];
@@ -49,6 +59,7 @@ export default function ProductsTable({ products, loading, error }: ProductsTabl
           <TableRow>
             <TableHead>Product ID</TableHead>
             <TableHead>Brand</TableHead>
+            <TableHead>Product Name</TableHead>
             <TableHead>Core</TableHead>
             <TableHead>Rank</TableHead>
             <TableHead>Net (incl.) After STA</TableHead>
@@ -67,7 +78,21 @@ export default function ProductsTable({ products, loading, error }: ProductsTabl
             <TableRow key={p.id}>
               <TableCell>{p.id}</TableCell>
               <TableCell>{p.brand_name || ""}</TableCell>
-              <TableCell>{p.core_group || ""}</TableCell>
+              <TableCell>{p.product_name || ""}</TableCell>
+              <TableCell>
+                {p.core_group ? (
+                  <span
+                    className={cn(
+                      "px-2 py-1 rounded-md text-xs font-medium",
+                      groupColors[p.core_group] || "bg-gray-100 text-gray-800",
+                    )}
+                  >
+                    {p.core_group}
+                  </span>
+                ) : (
+                  ""
+                )}
+              </TableCell>
               <TableCell>{p.rank ?? ""}</TableCell>
               <TableCell>{p.net_after_sta || ""}</TableCell>
               <TableCell>{p.go || ""}</TableCell>

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -6,6 +6,7 @@ const navigation = [
   { name: 'Product Management', href: '/products', icon: Box },
   { name: 'Distributors & Brands', href: '/distributors', icon: Warehouse },
   { name: 'CTC Hierarchy', href: '/ctc-hierarchy', icon: Box },
+  { name: 'Core Range Products', href: '/core-range-products', icon: Box },
   { name: 'Sales Analytics', href: '#', icon: ChartLine },
   { name: 'Inventory', href: '#', icon: Warehouse },
   { name: 'Customers', href: '#', icon: Users },

--- a/client/src/pages/core-range-products.tsx
+++ b/client/src/pages/core-range-products.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import Sidebar from "@/components/sidebar";
+import UserMenu from "@/components/user-menu";
+import Filters, { FilterValues } from "@/components/core-range/Filters";
+import ProductsTable from "@/components/core-range/ProductsTable";
+import TablePagination from "@/components/core-range/Pagination";
+import { apiRequest } from "@/lib/queryClient";
+import { Store, Bell } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface Product {
+  id: number;
+  [key: string]: any;
+}
+
+export default function CoreRangeProducts() {
+  const [filters, setFilters] = useState<FilterValues | null>(null);
+  const [page, setPage] = useState(0);
+  const ITEMS_PER_PAGE = 10;
+
+  const {
+    data: products = [],
+    isLoading,
+    isError,
+  } = useQuery<Product[]>({
+    queryKey: ["/products/core-range", filters],
+    queryFn: async () => {
+      if (!filters) return [];
+      const params = new URLSearchParams();
+      if (filters.distributor_id)
+        params.append("distributor_id", String(filters.distributor_id));
+      if (filters.brand_id) params.append("brand_id", String(filters.brand_id));
+      if (filters.class_id) params.append("class_id", String(filters.class_id));
+      if (filters.type_id) params.append("type_id", String(filters.type_id));
+      if (filters.category_id)
+        params.append("category_id", String(filters.category_id));
+      const res = await apiRequest(
+        "GET",
+        `/products/core-range?${params.toString()}`,
+      );
+      return res.json();
+    },
+    enabled: filters !== null,
+  });
+
+  const pageCount = Math.max(1, Math.ceil(products.length / ITEMS_PER_PAGE));
+  const paginated = products.slice(
+    page * ITEMS_PER_PAGE,
+    page * ITEMS_PER_PAGE + ITEMS_PER_PAGE,
+  );
+
+  const handleSubmit = (f: FilterValues) => {
+    setFilters(f);
+    setPage(0);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow-sm border-b border-gray-200 sticky top-0 z-50">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div className="flex items-center">
+              <Store className="text-primary text-2xl mr-3" />
+              <h1 className="text-xl font-semibold text-gray-900">Core Range Products</h1>
+            </div>
+            <div className="flex items-center space-x-4">
+              <Button variant="ghost" size="icon">
+                <Bell className="h-5 w-5 text-gray-400" />
+              </Button>
+              <UserMenu />
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="flex h-screen pt-16">
+        <Sidebar />
+        <main className="flex-1 overflow-auto p-6">
+          <Filters onSubmit={handleSubmit} />
+          <ProductsTable products={paginated} loading={isLoading} error={isError} />
+          {filters && (
+            <TablePagination
+              page={page}
+              pageCount={pageCount}
+              onPageChange={setPage}
+            />
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/core-range-products.tsx
+++ b/client/src/pages/core-range-products.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 interface Product {
   id: number;
   brand_name?: string;
+  ctc_class_name?: string;
   product_name?: string;
   core_group?: string;
   [key: string]: any;
@@ -44,7 +45,16 @@ export default function CoreRangeProducts() {
         "GET",
         `/products/core-range?${params.toString()}`,
       );
-      return res.json();
+      const data = await res.json();
+      return (data as any[]).map((p) => {
+        const go = p.price_levels?.find((pl: any) => pl.price_level === "GO");
+        return {
+          ...p,
+          go: go?.value_incl ?? go?.value_excl ?? p.go,
+        } as Product;
+      }).sort((a, b) =>
+        (a.ctc_class_name || "").localeCompare(b.ctc_class_name || "")
+      );
     },
     enabled: filters !== null,
   });

--- a/client/src/pages/core-range-products.tsx
+++ b/client/src/pages/core-range-products.tsx
@@ -35,6 +35,8 @@ export default function CoreRangeProducts() {
       if (filters.type_id) params.append("type_id", String(filters.type_id));
       if (filters.category_id)
         params.append("category_id", String(filters.category_id));
+      if (filters.core_groups && filters.core_groups.length)
+        params.append("core_groups", filters.core_groups.join(","));
       const res = await apiRequest(
         "GET",
         `/products/core-range?${params.toString()}`,

--- a/client/src/pages/core-range-products.tsx
+++ b/client/src/pages/core-range-products.tsx
@@ -11,6 +11,9 @@ import { Button } from "@/components/ui/button";
 
 interface Product {
   id: number;
+  brand_name?: string;
+  product_name?: string;
+  core_group?: string;
   [key: string]: any;
 }
 


### PR DESCRIPTION
## Summary
- add CoreRangeProducts page and route
- add navigation link in sidebar
- implement filter inputs using Select
- show data table for core range products
- provide pagination controls

## Testing
- `npm run check` *(fails: Property errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_687ed2abfee083288d042ccc61a8c7e3