### PR TITLE
Add settings page with theme toggle

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import ProductManagement from "@/pages/product-management";
 import DistributorsPage from "@/pages/distributors";
 import CTCHierarchyPage from "@/pages/ctc-hierarchy";
 import CoreRangeProducts from "@/pages/core-range-products";
+import SettingsPage from "@/pages/settings";
 import NotFound from "@/pages/not-found";
 import { keycloak, keycloakConfig } from "./keycloak";
 
@@ -20,6 +21,7 @@ function Router() {
       <Route path="/distributors" component={DistributorsPage} />
       <Route path="/ctc-hierarchy" component={CTCHierarchyPage} />
       <Route path="/core-range-products" component={CoreRangeProducts} />
+      <Route path="/settings" component={SettingsPage} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -10,7 +10,7 @@ const navigation = [
   { name: 'Sales Analytics', href: '#', icon: ChartLine },
   { name: 'Inventory', href: '#', icon: Warehouse },
   { name: 'Customers', href: '#', icon: Users },
-  { name: 'Settings', href: '#', icon: Settings },
+  { name: 'Settings', href: '/settings', icon: Settings },
 ];
 
 export default function Sidebar() {

--- a/client/src/components/theme-provider.tsx
+++ b/client/src/components/theme-provider.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === "undefined") return "light";
+    const stored = localStorage.getItem("theme");
+    return stored === "dark" ? "dark" : "light";
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((prev) => (prev === "light" ? "dark" : "light"));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,7 +1,10 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import { ThemeProvider } from "@/components/theme-provider";
 
 createRoot(document.getElementById("root")!).render(
-  <App />
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>
 );

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1,0 +1,40 @@
+import Sidebar from "@/components/sidebar";
+import UserMenu from "@/components/user-menu";
+import { Settings as SettingsIcon, Bell } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { useTheme } from "@/components/theme-provider";
+
+export default function SettingsPage() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow-sm border-b border-gray-200 sticky top-0 z-50">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div className="flex items-center">
+              <SettingsIcon className="text-primary text-2xl mr-3" />
+              <h1 className="text-xl font-semibold text-gray-900">Settings</h1>
+            </div>
+            <div className="flex items-center space-x-4">
+              <Bell className="h-5 w-5 text-gray-400" />
+              <UserMenu />
+            </div>
+          </div>
+        </div>
+      </header>
+      <div className="flex h-screen pt-16">
+        <Sidebar />
+        <main className="flex-1 overflow-auto p-6">
+          <div className="max-w-md mx-auto bg-white p-6 rounded shadow-sm">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="theme-toggle">Dark Mode</Label>
+              <Switch id="theme-toggle" checked={theme === "dark"} onCheckedChange={toggleTheme} />
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add global ThemeProvider with localStorage persistence
- wrap app in ThemeProvider
- add settings route and page for light/dark mode toggle
- update sidebar navigation link

## Testing
- `npm run check` *(fails: Property errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_688029b41bfc8328b8783c2399b5bdd3